### PR TITLE
TFIDF word embeddings

### DIFF
--- a/Models/README
+++ b/Models/README
@@ -1,0 +1,13 @@
+#TfidfVectorizer fitted to all abstracts in 'ectries' collection. Preprocessing is done with the matscholar function. To use it, you should add the following:
+
+from matscholar_core.nlp import relevance
+from sklearn.feature_extraction.text import TfidfVectorizer
+import dill as pickle
+
+with open('Models/tfidf.p', "rb") as f:
+	tfidf = dill.load(f)
+
+relClass = relevance.RelevanceClassifier()
+processed = relClass._preprocess(YOUR_DOCUMENT)
+
+X = tfidf.transform([processed])

--- a/Models/README
+++ b/Models/README
@@ -1,4 +1,4 @@
-#TfidfVectorizer fitted to all abstracts in 'ectries' collection. Preprocessing is done with the matscholar function. To use it, you should add the following:
+#TfidfVectorizer fitted to all abstracts in 'entries' collection and saved as pickle file. Preprocessing is done with the matscholar function. To use it, you should add the following:
 
 from matscholar_core.nlp import relevance
 from sklearn.feature_extraction.text import TfidfVectorizer


### PR DESCRIPTION
TfidfVectorizer fitted to all abstracts in 'entries' collection and saved as pickle file. Preprocessing is done with the matscholar function. Example of further usage is in README.